### PR TITLE
import linux docs

### DIFF
--- a/docs/deployment/index.txt
+++ b/docs/deployment/index.txt
@@ -11,5 +11,6 @@ environments.
    :maxdepth: 3
    :titlesonly:
 
+   linux/index
    containers/index
    cloud/index

--- a/docs/deployment/linux/debian.txt
+++ b/docs/deployment/linux/debian.txt
@@ -1,0 +1,200 @@
+.. _debian:
+
+===============================
+Run CrateDB on Debian GNU/Linux
+===============================
+
+CrateDB maintains packages for the follow Debian versions:
+
+- `Stretch`_ (9.x)
+- `Jessie`_ (8.x)
+- `Wheezy`_ (7.x)
+
+.. _Wheezy: https://www.debian.org/releases/wheezy/
+.. _Jessie: https://www.debian.org/releases/jessie/
+.. _Stretch: https://www.debian.org/releases/stretch/
+
+This document will walk you through the process of installing and configuring
+the CrateDB Debian package.
+
+.. TIP::
+
+   This document targets production deployments.
+
+   If you're just getting started with CrateDB, we also provide a `one-step
+   Linux installer`_ .
+
+.. _one-step Linux installer: https://crate.io/docs/crate/getting-started/en/latest/install-run/special/linux.html
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Configure Apt
+=============
+
+Firstly, you will need to upgrade `Apt`_ (the Debian package manager) with HTTPS
+support, like so:
+
+.. _Apt: https://wiki.debian.org/Apt
+
+.. code-block:: sh
+
+   sh$ sudo apt-get install apt-transport-https
+
+After that, you will need to download the CrateDB GPG key:
+
+.. code-block:: sh
+
+   sh$ wget https://cdn.crate.io/downloads/apt/DEB-GPG-KEY-crate
+
+And then, so that Apt trusts the CrateDB repository, add the key:
+
+.. code-block:: sh
+
+   sh$ sudo apt-key add DEB-GPG-KEY-crate
+
+CrateDB provides a stable and a testing release channel. At this point, you
+should select which one you wish to use.
+
+Create an Apt configuration file, like so:
+
+.. code-block:: sh
+
+   sh$ sudo touch /etc/apt/sources.list.d/crate-CHANNEL.list
+
+Here, replace ``CHANNEL`` with ``stable`` or ``testing``, depending on which
+release channel you plan to use.
+
+Then, edit it, and add the following:
+
+.. code-block:: text
+
+   deb https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
+   deb-src https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
+
+Here, replace ``CHANNEL`` as above, and then, additionally, replace
+``CODENAME`` with the codename of your distribution, which be ``wheezy``,
+``jessie``, or ``stretch``.
+
+Additional Steps
+================
+
+.. CAUTION::
+
+   CrateDB requires Java 8 or higher.
+
+   To run CrateDB on Debian releases older than Debian Stretch, you will need to
+   follow some additional steps.
+
+Debian Jessie (8.x)
+-------------------
+
+Debian Jessie provides Java 8 via the `backports`_ repository.
+
+.. _backports: https://backports.debian.org/
+
+You can set up the backports repository like so:
+
+.. code-block:: sh
+
+   sh$ REPO_URL="http://http.debian.net/debian"
+
+   sh$ echo "deb $REPO_URL jessie-backports main" | sudo tee -a /etc/apt/sources.list
+
+.. _debian-wheezy:
+
+Debian Wheezy (7.x)
+-------------------
+
+Debian Wheezy does not officially ship with Java 8, so you will have to install
+it from a third party repository.
+
+We recommend the `WebUpd8 team`_ repository, which you can configure like so:
+
+.. _WebUpd8 team: https://launchpad.net/~webupd8team
+
+.. code-block:: sh
+
+   sh$ REPO_URL="http://ppa.launchpad.net/webupd8team/java/ubuntu"
+
+   sh$ echo "deb $REPO_URL precise main" | sudo tee -a /etc/apt/sources.list
+   sh$ echo "deb-src $REPO_URL precise main" | sudo tee -a /etc/apt/sources.list
+
+   sh$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
+   sh$ sudo apt-get update
+   sh$ sudo apt-get install oracle-java8-installer
+
+Install CrateDB
+===============
+
+With everything set up, you can install CrateDB, like so:
+
+.. code-block:: sh
+
+   sh$ sudo apt-get update
+   sh$ sudo apt-get install crate
+
+After the installation is finished, the ``crate`` service should be
+up-and-running.
+
+You should be able to access it by visiting::
+
+  http://localhost:4200/
+
+.. TIP::
+
+   If you're new to CrateDB, check out our our `first use`_ documentation.
+
+.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
+
+Controlling CrateDB
+===================
+
+With Debian Jessie (8.x) and above, you can control the ``crate`` service like
+so:
+
+.. code-block:: sh
+
+    sh$ sudo systemctl COMMAND crate
+
+With Debian Wheezy (9.x), you must do this instead:
+
+.. code-block:: sh
+
+    sh$ sudo /etc/init.d/crate COMMAND
+
+In both instances, replace ``COMMAND`` with ``start``, ``stop``, ``restart``,
+``status``, etc.
+
+Configuration
+=============
+
+The CrateDB startup script `sources`_ environment variables from the
+``/etc/default/crate`` file.
+
+.. _sources: https://en.wikipedia.org/wiki/Source_(command)
+
+You can use this mechanism to configure CrateDB.
+
+Here's one example:
+
+.. code-block:: sh
+
+   # Heap Size (defaults to 256m min, 1g max)
+   CRATE_HEAP_SIZE=2g
+
+   # Maximum number of open files, defaults to 65535.
+   # MAX_OPEN_FILES=65535
+
+   # Maximum locked memory size. Set to "unlimited" if you use the
+   # bootstrap.mlockall option in crate.yml. You must also set
+   # CRATE_HEAP_SIZE.
+   MAX_LOCKED_MEMORY=unlimited
+
+   # Additional Java OPTS
+   # CRATE_JAVA_OPTS=
+
+   # Force the JVM to use IPv4 stack
+   CRATE_USE_IPV4=true

--- a/docs/deployment/linux/index.txt
+++ b/docs/deployment/linux/index.txt
@@ -1,0 +1,16 @@
+.. _linux:
+
+=================
+CrateDB and Linux
+=================
+
+CrateDB provides a number of Linux packages.
+
+.. rubric:: Table of Contents
+
+.. toctree::
+   :maxdepth: 1
+
+   debian
+   red-hat
+   ubuntu

--- a/docs/deployment/linux/red-hat.txt
+++ b/docs/deployment/linux/red-hat.txt
@@ -1,0 +1,133 @@
+.. _red-hat:
+
+============================
+Run CrateDB on Red Hat Linux
+============================
+
+CrateDB maintains the official RPM repositories for:
+
+- `Red Hat Linux 7`_
+- `Red Hat Linux 6`_
+
+.. _Red Hat Linux 7: https://www.redhat.com/en/resources/whats-new-red-hat-enterprise-linux-7
+.. _Red Hat Linux 6: https://www.redhat.com/en/resources/red-hat-enterprise-linux-6
+
+Both of these work with RedHat Enterprise Linux, CentOS, and Scientific Linux.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Configure YUM
+=============
+
+All CrateDB packages are signed with GPG.
+
+To get started, you must import the CrateDB public key, like so:
+
+.. code-block:: sh
+
+   sh$ sudo rpm --import https://cdn.crate.io/downloads/yum/RPM-GPG-KEY-crate
+
+You must then install the CrateDB repository definition.
+
+For Red Hat Linux 7, run:
+
+.. code-block:: sh
+
+   sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/7/noarch/crate-release-7.0-1.noarch.rpm
+
+For Red Hat Linux 6, run:
+
+.. code-block:: sh
+
+   sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/6/x86_64/crate-release-6.5-1.noarch.rpm
+
+Both of the above commands will create the ``/etc/yum.repos.d/crate.repo``
+configuration file.
+
+CrateDB provides a stable and a testing release channel. At this point, you
+should select which one you wish to use.
+
+By default, `YUM`_ (Red Hat's package manager) will use the stable repository.
+This is because the testing repository's configuration marks it as disabled.
+
+.. _YUM: https://access.redhat.com/solutions/9934
+
+If you would like to enable to testing repository, open the ``crate.repo`` file
+and set ``enabled=1`` under the ``[crate-testing]`` section.
+
+Install CrateDB
+===============
+
+With everything set up, you can install CrateDB, like so:
+
+.. code-block:: sh
+
+   yum install crate
+
+CrateDB is now installed, but not running.
+
+Running and Controlling CrateDB
+===============================
+
+With Red Hat Linux 7, you can control the ``crate`` service like so:
+
+.. code-block:: sh
+
+   sh$ sudo systemctl COMMAND crate
+
+With Red Hat Linux 6, you should use:
+
+.. code-block:: sh
+
+   sh$ sudo service crate COMMAND
+
+In both instances, replace ``COMMAND`` with ``start``, ``stop``, ``restart``,
+``status``, etc.
+
+After you run the appropriate command with the ``start`` argument, the
+``crate`` service should be up-and-running.
+
+You should be able to access it by visiting::
+
+  http://localhost:4200/
+
+.. TIP::
+
+   If you're new to CrateDB, check out our our `first use`_ documentation.
+
+.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
+
+
+Configuration
+=============
+
+The CrateDB startup script `sources`_ environment variables from the
+``/etc/sysconfig/crate`` file.
+
+.. _sources: https://en.wikipedia.org/wiki/Source_(command)
+
+You can use this mechanism to configure CrateDB.
+
+Here's one example:
+
+.. code-block:: sh
+
+   # Heap Size (defaults to 256m min, 1g max)
+   CRATE_HEAP_SIZE=2g
+
+   # Maximum number of open files, defaults to 65535.
+   # MAX_OPEN_FILES=65535
+
+   # Maximum locked memory size. Set to "unlimited" if you use the
+   # bootstrap.mlockall option in crate.yml. You must also set
+   # CRATE_HEAP_SIZE.
+   MAX_LOCKED_MEMORY=unlimited
+
+   # Additional Java OPTS
+   # CRATE_JAVA_OPTS=
+
+   # Force the JVM to use IPv4 stack
+   CRATE_USE_IPV4=true

--- a/docs/deployment/linux/ubuntu.txt
+++ b/docs/deployment/linux/ubuntu.txt
@@ -1,0 +1,204 @@
+.. _ubuntu:
+
+=====================
+Run CrateDB on Ubuntu
+=====================
+
+CrateDB maintains packages for the following Ubuntu versions:
+
+- `Artful Aardvark` (17.10)
+- `Zesty Zapus`_ (17.04)
+- `Yakkety Yak`_ (16.10)
+- `Xenial Xerus`_ (16.04)
+- `Trusty Tahr`_ (14.04)
+
+.. _Artful Aardvark: https://wiki.ubuntu.com/ArtfulAardvark/ReleaseNotes
+.. _Zesty Zapus: https://wiki.ubuntu.com/ZestyZapus/ReleaseNotes
+.. _Yakkety Yak: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes
+.. _Xenial Xerus: https://wiki.ubuntu.com/XenialXerus/ReleaseNotes
+.. _Trusty Tahr: https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes
+
+.. CAUTION::
+
+   CrateDB requires Java 8 or higher.
+
+   To run CrateDB on Ubuntu releases older than Trusty Tahr 14.10, you will need
+   to :ref:`install Java 8 from a 3rd party repository <debian-wheezy>`.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Configure Apt
+=============
+
+CrateDB 2.1.0 or Higher
+-----------------------
+
+.. NOTE::
+
+   The official CrateDB repository only contains CrateDB 2.1.0 or higher.
+
+   Consult the section for `Older Versions`_ if necessary.
+
+Firstly, you will need to configure `Apt`_ (the Ubuntu package manager) to trust
+the CrateDB repository.
+
+.. _Apt: https://wiki.debian.org/Apt
+
+Download the CrateDB GPG key:
+
+.. code-block:: sh
+
+   sh$ wget https://cdn.crate.io/downloads/apt/DEB-GPG-KEY-crate
+
+And then add the key to Apt:
+
+.. code-block:: sh
+
+   sh$ sudo apt-key add DEB-GPG-KEY-crate
+
+CrateDB provides a stable release and a testing release channel. At this point,
+you should select which one you wish to use.
+
+Create an Apt configuration file, like so:
+
+.. code-block:: sh
+
+   sh$ sudo touch /etc/apt/sources.list.d/crate-CHANNEL.list
+
+Here, replace ``CHANNEL`` with ``stable`` or ``testing``, depending on which
+type of release channel you plan to use.
+
+Then, edit it, and add the following:
+
+.. code-block:: text
+
+   deb https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
+   deb-src https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
+
+Here, replace ``CHANNEL`` as above, and then, additionally, replace
+``CODENAME`` with the codename of your distribution, which can be round by
+running:
+
+.. code-block:: sh
+
+   sh$ source /etc/os-release && echo $UBUNTU_CODENAME
+
+You can now install CrateDB.
+
+Skip to `Install CrateDB`_.
+
+Older Versions
+--------------
+
+.. CAUTION::
+
+   This method of installation has been deprecated and does not support CrateDB
+   2.1.0 or higher.
+
+For version of CrateDB older than 2.1.0, you will have to install from an
+official, but unmaintained, `PPA repository`_.
+
+.. _PPA repository: https://launchpad.net/ubuntu/+ppas
+
+Firstly, you will need to install package that allows you to add new PPA repositories:
+
+.. code-block:: sh
+
+   sh$ sudo apt-get install python-software-properties
+
+If you're running Xenial Xerus (16.04) or higher, you will also need to
+install this package:
+
+.. code-block:: sh
+
+   sh$ sudo apt-get install software-properties-common
+
+CrateDB provides a stable and a testing release channel. At this point, you
+should select which one you wish to use.
+
+Now, it will be possible to add the PPA repository, like so:
+
+.. code-block:: sh
+
+   sh$ sudo add-apt-repository ppa:crate/CHANNEL
+
+Here, replace ``CHANNEL`` with ``stable`` or ``testing``, depending on which
+release channel you plan to use.
+
+You can now install CrateDB.
+
+Install CrateDB
+===============
+
+With everything set up, you can install CrateDB, like so:
+
+.. code-block:: sh
+
+   sh$ sudo apt-get update
+   sh$ sudo apt-get install crate
+
+After the installation is finished, the ``crate`` service should be
+up-and-running.
+
+You should be able to access it by visiting::
+
+  http://localhost:4200/
+
+.. TIP::
+
+   If you're new to CrateDB, check out our our `first use`_ documentation.
+
+.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
+
+Controlling CrateDB
+===================
+
+With Xenial Xerus (15.04) and above, you can control the ``crate`` service like
+so:
+
+.. code-block:: sh
+
+   sh$ sudo systemctl COMMAND crate
+
+With Trusty Tahr (14.04), you should use:
+
+.. code-block:: sh
+
+   sh$ sudo service crate COMMAND
+
+In both instances, replace ``COMMAND`` with ``start``, ``stop``, ``restart``,
+``status``, etc.
+
+Configuration
+=============
+
+The CrateDB startup script `sources`_ environment variables from the
+``/etc/default/crate`` file.
+
+.. _sources: https://en.wikipedia.org/wiki/Source_(command)
+
+You can use this mechanism to configure CrateDB.
+
+Here's one example:
+
+.. code-block:: sh
+
+   # Heap Size (defaults to 256m min, 1g max)
+   CRATE_HEAP_SIZE=2g
+
+   # Maximum number of open files, defaults to 65535.
+   # MAX_OPEN_FILES=65535
+
+   # Maximum locked memory size. Set to "unlimited" if you use the
+   # bootstrap.mlockall option in crate.yml. You must also set
+   # CRATE_HEAP_SIZE.
+   MAX_LOCKED_MEMORY=unlimited
+
+   # Additional Java OPTS
+   # CRATE_JAVA_OPTS=
+
+   # Force the JVM to use IPv4 stack
+   CRATE_USE_IPV4=true


### PR DESCRIPTION
this is an import from the docs that originally lived in the "getting started" guide. because these are not appropriate docs for getting started. we have an automatically installer, which is what we now recommend. we then link to the guide, to these docs, for the full information

these docs have undergone substantial rewriting, and I would like a technical check as well as just a normal review. thanks!