### PR TITLE
Update ec2 discovery property name

### DIFF
--- a/docs/deployment/cloud/aws/ec2-setup.txt
+++ b/docs/deployment/cloud/aws/ec2-setup.txt
@@ -37,9 +37,9 @@ will allow CrateDB to accept and respond to pings from other CrateDB instances
 with the same cluster name and form a cluster.
 
 Once you have your instances running and CrateDB installed, you can enable the
-EC2 discovery by setting the discovery type to ``ec2``::
+EC2 discovery by setting ``discovery.zen.hosts_provider`` to ``ec2``::
 
-  discovery.type: ec2
+  discovery.zen.hosts_provider: ec2
 
 To be able to use the EC2 API, CrateDB must `sign the requests`_ by using
 AWS credentials consisting of an access key and a secret key. Therefore


### PR DESCRIPTION
Per discussion in Slack, the documented `discovery.type: ec2` config property causes the following warning in the logs:

```
[2018-03-06T15:01:46,933][WARN ][o.e.d.d.e.Ec2DiscoveryPlugin] using [discovery.type] setting to set hosts provider is deprecated; set [discovery.zen.hosts_provider: ec2] instead
```

Changing this property to the new `discovery.zen.hosts_provider: ec2` removes this warning.