### PR TITLE
Mark USR2 signal node stop as deprecated

### DIFF
--- a/docs/admin/rolling-upgrade.txt
+++ b/docs/admin/rolling-upgrade.txt
@@ -126,6 +126,13 @@ Use the `SET`_ command to do so:
 Step 2: Graceful Stop
 ---------------------
 
+There are two ways of stopping a ``crate`` node:
+
+1. Use the ``ALTER CLUSTER DECOMMISSION`` statement.
+   See `Decommission Statement`_ for usage.
+
+2. Kill the process using the ``USR2`` signal
+
 The ``crate`` process supports multiple signals (see `Signal Handling`_) that
 invoke different shutdown procedures. To stop a CrateDB process gracefully you
 need to send the ``USR2`` signal::
@@ -142,10 +149,11 @@ need to send the ``USR2`` signal::
     Stopping a crate process using the ``USR2`` signal is deprecated
     and will be removed in a future release.
 
-Depending on the size of your cluster this might take a while. You might want
-to check your server logs to see if the graceful stop process is progressing
-well. In case of an error or a timeout, the node will stay up, signaling the
-error in its log files (or wherever you put your log messages).
+Depending on the size of your cluster, stopping a ``crate`` node might take
+a while. You might want to check your server logs to see if the graceful stop
+process is progressing well. In case of an error or a timeout, the node will
+stay up, signaling the error in its log files (or wherever you put your log
+messages).
 
 Using the default settings the node will shut down by moving all primary shards
 off the node first. This will ensure that no data is lost. However, the cluster
@@ -299,3 +307,4 @@ again that have been disabled in the first step:
 .. _Signal Handling: https://crate.io/docs/crate/reference/cli.html#signal-handling
 .. _SET: https://crate.io/docs/crate/reference/sql/reference/set.html
 .. _Graceful Stop: https://crate.io/docs/crate/reference/configuration.html#graceful-stop
+.. _Decommission Statement: https://crate.io/docs/crate/reference/en/latest/sql/statements/alter-cluster.html#decommission-nodeid-nodename

--- a/docs/admin/rolling-upgrade.txt
+++ b/docs/admin/rolling-upgrade.txt
@@ -137,6 +137,11 @@ need to send the ``USR2`` signal::
   If your system uses SysVinit (e.g. Debian Wheezy), you can also use ``service
   crate graceful-stop``.
 
+.. WARNING::
+
+    Stopping a crate process using the ``USR2`` signal is deprecated
+    and will be removed in a future release.
+
 Depending on the size of your cluster this might take a while. You might want
 to check your server logs to see if the graceful stop process is progressing
 well. In case of an error or a timeout, the node will stay up, signaling the


### PR DESCRIPTION
relates to crate/crate#8163