### PR TITLE
Update linux installation instructions

### DIFF
--- a/docs/deployment/linux/debian.txt
+++ b/docs/deployment/linux/debian.txt
@@ -7,11 +7,7 @@ Run CrateDB on Debian GNU/Linux
 CrateDB maintains packages for the follow Debian versions:
 
 - `Stretch`_ (9.x)
-- `Jessie`_ (8.x)
-- `Wheezy`_ (7.x)
 
-.. _Wheezy: https://www.debian.org/releases/wheezy/
-.. _Jessie: https://www.debian.org/releases/jessie/
 .. _Stretch: https://www.debian.org/releases/stretch/
 
 This document will walk you through the process of installing and configuring
@@ -88,51 +84,6 @@ You should see a success message. This indicates that the CrateDB release
 channel is correctly configured and the ``crate`` package has been registered
 locally.
 
-Additional Steps
-================
-
-CrateDB requires Java 8 or higher.
-
-To run CrateDB on Debian releases older than Debian Stretch, you will need to
-follow some additional steps.
-
-Debian Jessie (8.x)
--------------------
-
-Debian Jessie provides Java 8 via the `backports`_ repository.
-
-.. _backports: https://backports.debian.org/
-
-You can set up the backports repository like so:
-
-.. code-block:: sh
-
-   sh$ REPO_URL="http://http.debian.net/debian"
-
-   sh$ echo "deb $REPO_URL jessie-backports main" | sudo tee -a /etc/apt/sources.list
-
-.. _debian-wheezy:
-
-Debian Wheezy (7.x)
--------------------
-
-Debian Wheezy does not officially ship with Java 8, so you will have to install
-it from a third party repository.
-
-We recommend the `WebUpd8 team`_ repository, which you can configure like so:
-
-.. _WebUpd8 team: https://launchpad.net/~webupd8team
-
-.. code-block:: sh
-
-   sh$ REPO_URL="http://ppa.launchpad.net/webupd8team/java/ubuntu"
-
-   sh$ echo "deb $REPO_URL precise main" | sudo tee -a /etc/apt/sources.list
-   sh$ echo "deb-src $REPO_URL precise main" | sudo tee -a /etc/apt/sources.list
-
-   sh$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
-   sh$ sudo apt-get update
-   sh$ sudo apt-get install oracle-java8-installer
 
 Install CrateDB
 ===============
@@ -166,14 +117,7 @@ so:
 
     sh$ sudo systemctl COMMAND crate
 
-With Debian Wheezy (9.x), you must do this instead:
-
-.. code-block:: sh
-
-    sh$ sudo /etc/init.d/crate COMMAND
-
-In both instances, replace ``COMMAND`` with ``start``, ``stop``, ``restart``,
-``status``, etc.
+Replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status``, etc.
 
 .. CAUTION::
 

--- a/docs/deployment/linux/debian.txt
+++ b/docs/deployment/linux/debian.txt
@@ -117,7 +117,8 @@ so:
 
     sh$ sudo systemctl COMMAND crate
 
-Replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status``, etc.
+Here, replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status`` and
+so on.
 
 .. CAUTION::
 

--- a/docs/deployment/linux/red-hat.txt
+++ b/docs/deployment/linux/red-hat.txt
@@ -7,10 +7,8 @@ Run CrateDB on Red Hat Linux
 CrateDB maintains the official RPM repositories for:
 
 - `Red Hat Linux 7`_
-- `Red Hat Linux 6`_
 
 .. _Red Hat Linux 7: https://www.redhat.com/en/resources/whats-new-red-hat-enterprise-linux-7
-.. _Red Hat Linux 6: https://www.redhat.com/en/resources/red-hat-enterprise-linux-6
 
 Both of these work with RedHat Enterprise Linux, CentOS, and Scientific Linux.
 
@@ -38,13 +36,7 @@ For Red Hat Linux 7, run:
 
    sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/7/noarch/crate-release-7.0-1.noarch.rpm
 
-For Red Hat Linux 6, run:
-
-.. code-block:: sh
-
-   sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/6/x86_64/crate-release-6.5-1.noarch.rpm
-
-Both of the above commands will create the ``/etc/yum.repos.d/crate.repo``
+The above commands will create the ``/etc/yum.repos.d/crate.repo``
 configuration file.
 
 CrateDB provides a stable and a testing release channel. At this point, you
@@ -78,14 +70,7 @@ With Red Hat Linux 7, you can control the ``crate`` service like so:
 
    sh$ sudo systemctl COMMAND crate
 
-With Red Hat Linux 6, you should use:
-
-.. code-block:: sh
-
-   sh$ sudo service crate COMMAND
-
-In both instances, replace ``COMMAND`` with ``start``, ``stop``, ``restart``,
-``status``, etc.
+Replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status``, etc.
 
 After you run the appropriate command with the ``start`` argument, the
 ``crate`` service should be up-and-running.

--- a/docs/deployment/linux/red-hat.txt
+++ b/docs/deployment/linux/red-hat.txt
@@ -70,7 +70,8 @@ With Red Hat Linux 7, you can control the ``crate`` service like so:
 
    sh$ sudo systemctl COMMAND crate
 
-Replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status``, etc.
+Here, replace ``COMMAND`` with ``start``, ``stop``, ``restart``, ``status`` and
+so on.
 
 After you run the appropriate command with the ``start`` argument, the
 ``crate`` service should be up-and-running.

--- a/docs/deployment/linux/ubuntu.txt
+++ b/docs/deployment/linux/ubuntu.txt
@@ -7,16 +7,10 @@ Run CrateDB on Ubuntu
 CrateDB maintains packages for the following Ubuntu versions:
 
 - `Bionic Beaver`_ (18.04)
-- `Artful Aardvark`_ (17.10)
-- `Zesty Zapus`_ (17.04)
-- `Yakkety Yak`_ (16.10)
 - `Xenial Xerus`_ (16.04)
 - `Trusty Tahr`_ (14.04)
 
 .. _Bionic Beaver: https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes
-.. _Artful Aardvark: https://wiki.ubuntu.com/ArtfulAardvark/ReleaseNotes
-.. _Zesty Zapus: https://wiki.ubuntu.com/ZestyZapus/ReleaseNotes
-.. _Yakkety Yak: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes
 .. _Xenial Xerus: https://wiki.ubuntu.com/XenialXerus/ReleaseNotes
 .. _Trusty Tahr: https://wiki.ubuntu.com/TrustyTahr/ReleaseNotes
 
@@ -24,8 +18,12 @@ CrateDB maintains packages for the following Ubuntu versions:
 
    CrateDB requires Java 8 or higher.
 
-   To run CrateDB on Ubuntu releases older than Trusty Tahr 14.10, you will need
-   to :ref:`install Java 8 from a 3rd party repository <debian-wheezy>`.
+   To run CrateDB on Ubuntu releases older than 16.04, you will need to install
+   Java from a 3rd party repository. This can be done by adding the openjdk ppa:
+
+      sh$ sudo add-apt-repository ppa:openjdk-r/ppa
+      sh$ sudo apt-get update
+      sh$ apt-get install -y openjdk-11-jre-headless
 
 .. rubric:: Table of Contents
 

--- a/docs/deployment/linux/ubuntu.txt
+++ b/docs/deployment/linux/ubuntu.txt
@@ -19,7 +19,8 @@ CrateDB maintains packages for the following Ubuntu versions:
    CrateDB requires Java 8 or higher.
 
    To run CrateDB on Ubuntu releases older than 16.04, you will need to install
-   Java from a 3rd party repository. This can be done by adding the openjdk ppa:
+   Java from a third-party repository. This can be done by adding the openjdk
+   PPA:
 
       sh$ sudo add-apt-repository ppa:openjdk-r/ppa
       sh$ sudo apt-get update


### PR DESCRIPTION
- Removes instructions for distros based on Red Hat 6
 - Removes Debian 7 and 8. We only support the latest
 - Removes the intermediate Ubuntu releases, we only support the LTS
 versions
 - Removes the instructions about using `/etc/init.d/` on Debian 9. That
 was incorrect, is also using systemd.
 - Adapts the instruction on how to install JDK on Ubuntu < 16. There
 java 8 is not in the stock repository. (It is now recommending to
 install java 11)