### PR TITLE
Install JRE as root in Ubuntu docs

### DIFF
--- a/docs/deployment/linux/ubuntu.txt
+++ b/docs/deployment/linux/ubuntu.txt
@@ -24,7 +24,7 @@ CrateDB maintains packages for the following Ubuntu versions:
 
       sh$ sudo add-apt-repository ppa:openjdk-r/ppa
       sh$ sudo apt-get update
-      sh$ apt-get install -y openjdk-11-jre-headless
+      sh$ sudo apt-get install -y openjdk-11-jre-headless
 
 .. rubric:: Table of Contents
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Like the other two commands in the code block, running `apt-get install` requires root privileges as well. Thus, prefix the command with `sudo` would be correct.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
