### PR TITLE
Update Docker guide to use Zen2 discovery settings

### DIFF
--- a/docs/deployment/containers/docker.txt
+++ b/docs/deployment/containers/docker.txt
@@ -100,7 +100,12 @@ So, let's create a second node, called ``crate02``, and configure it to ping
     sh$ docker run -d --name=crate02 \
           --net=crate -p 4202:4200 --env CRATE_HEAP_SIZE=2g \
           crate -Cnetwork.host=_site_ \
-                -Cdiscovery.zen.ping.unicast.hosts=crate01
+                -Cdiscovery.seed_hosts=crate01
+
+.. NOTE::
+
+    In versions of CrateDB prior to 4.0, you must use
+    ``discovery.zen.ping.unicast.hosts`` instead of ``discovery.seed_hosts``.
 
 Notice here how we also updated the port mapping, so that port ``4200`` on the
 container is mapped to ``4202`` on our host machine.
@@ -116,7 +121,12 @@ You can now add subsequent nodes, like so::
     sh$ docker run -d --name=crate03 \
           --net=crate -p 4203:4200  --env CRATE_HEAP_SIZE=2g \
           crate -Cnetwork.host=_site_ \
-                -Cdiscovery.zen.ping.unicast.hosts=crate01,crate02
+                -Cdiscovery.seed_hosts=crate01,crate02
+
+.. NOTE::
+
+    In versions of CrateDB prior to 4.0, you must use
+    ``discovery.zen.ping.unicast.hosts`` instead of ``discovery.seed_hosts``.
 
 .. NOTE::
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

CrateDB 4.0 switched to Zen2 as a discovery algorithm. As part of that, some configuration settings changed that needed to be updated




## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
