### PR TITLE
3rd party openjdk 11 is needed for Ubuntu < 18.04

### DIFF
--- a/docs/deployment/linux/ubuntu.txt
+++ b/docs/deployment/linux/ubuntu.txt
@@ -18,7 +18,7 @@ CrateDB maintains packages for the following Ubuntu versions:
 
    CrateDB requires Java 11 or higher.
 
-   To run CrateDB on Ubuntu releases older than 16.04, you will need to install
+   To run CrateDB on Ubuntu releases older than 18.04, you will need to install
    Java from a third-party repository. This can be done by adding the openjdk
    PPA::
 


### PR DESCRIPTION
Ubuntu 16.04 only ships openjdk 8/9, so even for that distribution, installing
openjdk-11 from a third-party repository is required.